### PR TITLE
resolve dependency-file-generator warning

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,7 +41,7 @@ repos:
         types_or: [c, c++, cuda]
         args: ["-fallback-style=none", "-style=file", "-i"]
   - repo: https://github.com/rapidsai/dependency-file-generator
-    rev: v1.8.0
+    rev: v1.13.11
     hooks:
         - id: rapids-dependency-file-generator
           args: ["--clean"]

--- a/ci/build_docs.sh
+++ b/ci/build_docs.sh
@@ -8,7 +8,7 @@ rapids-logger "Create test conda environment"
 
 rapids-dependency-file-generator \
   --output conda \
-  --file_key docs \
+  --file-key docs \
   --matrix "cuda=${RAPIDS_CUDA_VERSION%.*};arch=$(arch);py=${RAPIDS_PY_VERSION}" | tee env.yaml
 
 rapids-mamba-retry env create --force -f env.yaml -n docs

--- a/ci/check_style.sh
+++ b/ci/check_style.sh
@@ -8,7 +8,7 @@ rapids-logger "Create checks conda environment"
 
 rapids-dependency-file-generator \
   --output conda \
-  --file_key checks \
+  --file-key checks \
   --matrix "cuda=${RAPIDS_CUDA_VERSION%.*};arch=$(arch);py=${RAPIDS_PY_VERSION}" | tee env.yaml
 
 rapids-mamba-retry env create --force -f env.yaml -n checks

--- a/ci/test_notebooks.sh
+++ b/ci/test_notebooks.sh
@@ -8,7 +8,7 @@ set -Eeuo pipefail
 rapids-logger "Generate notebook testing dependencies"
 rapids-dependency-file-generator \
   --output conda \
-  --file_key test_notebooks \
+  --file-key test_notebooks \
   --matrix "cuda=${RAPIDS_CUDA_VERSION%.*};arch=$(arch);py=${RAPIDS_PY_VERSION}" | tee env.yaml
 
 rapids-mamba-retry env create --force -f env.yaml -n test

--- a/ci/test_python.sh
+++ b/ci/test_python.sh
@@ -15,7 +15,7 @@ cd "$(dirname "$(realpath "${BASH_SOURCE[0]}")")"/../
 rapids-logger "Generate Python testing dependencies"
 rapids-dependency-file-generator \
   --output conda \
-  --file_key test_python \
+  --file-key test_python \
   --matrix "cuda=${RAPIDS_CUDA_VERSION%.*};arch=$(arch);py=${RAPIDS_PY_VERSION}" | tee env.yaml
 
 rapids-mamba-retry env create --force -f env.yaml -n test


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/dependency-file-generator/issues/89

Argument `--file_key` to `rapids-dependency-file-generator` is deprecated, in favor of `--file-key`. I'm going around repos using that project making that change, to resolve this warning you may be seeing in CI:

> /opt/conda/lib/python3.9/site-packages/rapids_dependency_file_generator/cli.py:98: UserWarning: The use of --file_key is deprecated. Use -f or --file-key instead.

And to get us closer to being able to fully remove that deprecated argument.