### PR TITLE
Avoid --find-links in wheel jobs

### DIFF
--- a/ci/build_wheel_cugraph_kg.sh
+++ b/ci/build_wheel_cugraph_kg.sh
@@ -1,16 +1,20 @@
 #!/bin/bash
-# Copyright (c) 2023, NVIDIA CORPORATION.
+# Copyright (c) 2023-2024, NVIDIA CORPORATION.
 
 set -euo pipefail
 
 RAPIDS_PY_CUDA_SUFFIX="$(rapids-wheel-ctk-name-gen ${RAPIDS_CUDA_VERSION})"
 
 # Download the pylibcugraph wheel built in the previous step and make it
-# available for pip to find. We must use PIP_FIND_LINKS because the package
-# must be made available to the isolated build step, and there is no way to
-# manually install it into that environment.
+# available for pip to find.
+#
+# ensure 'cugraph' wheel builds always use the 'pylibcugraph' just built in the same CI run
+#
+# using env variable PIP_CONSTRAINT is necessary to ensure the constraints
+# are used when creating the isolated build environment
 RAPIDS_PY_WHEEL_NAME=pylibcugraph_${RAPIDS_PY_CUDA_SUFFIX} rapids-download-wheels-from-s3 ./local-pylibcugraph
-export PIP_FIND_LINKS=$(pwd)/local-pylibcugraph
+echo "pylibcugraph-${RAPIDS_PY_CUDA_SUFFIX} @ file://$(echo ${PWD}/local-pylibcugraph/pylibcugraph_*.whl)" > ./constraints.txt
+export PIP_CONSTRAINT="${PWD}/constraints.txt"
 
 export SKBUILD_CMAKE_ARGS="-DDETECT_CONDA_ENV=OFF;-DFIND_CUGRAPH_CPP=OFF;-DCPM_cugraph-ops_SOURCE=${GITHUB_WORKSPACE}/cugraph-ops/"
 


### PR DESCRIPTION
## Description

Contributes to https://github.com/rapidsai/build-planning/issues/69
Contributes to https://github.com/rapidsai/build-planning/issues/33

Similar to https://github.com/rapidsai/cugraph-gnn/pull/7

https://github.com/rapidsai/cugraph/pull/4509 proposed a stricter pattern for passing a `pylibcugraph` wheel from the `wheel-build-cpp` job that produced it into the `wheel-build-python` job wanting to use it (as a build dependency of `cugraph`). This change improves the likelihood that issues with the `pylibcugraph` wheels will be caught in CI.

This proposes porting that change here, so that when CI is set up in this repo, it'll also benefit from that strictness.