### PR TITLE
skip CMake 3.30.0

### DIFF
--- a/ci/wheel_smoke_test_cugraph_kg.py
+++ b/ci/wheel_smoke_test_cugraph_kg.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, NVIDIA CORPORATION.
+# Copyright (c) 2023-2024, NVIDIA CORPORATION.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -13,7 +13,7 @@
 
 import cudf
 import cugraph
-import cugraph-kg
+import cugraph_pg
 
 if __name__ == "__main__":
     edgelist = cudf.DataFrame({"source": ["a", "b", "c"], "destination": ["b", "c", "d"]})

--- a/ci/wheel_smoke_test_cugraph_kg.py
+++ b/ci/wheel_smoke_test_cugraph_kg.py
@@ -13,7 +13,6 @@
 
 import cudf
 import cugraph
-import cugraph_pg
 
 if __name__ == "__main__":
     edgelist = cudf.DataFrame({"source": ["a", "b", "c"], "destination": ["b", "c", "d"]})

--- a/ci/wheel_smoke_test_cugraph_kg.py
+++ b/ci/wheel_smoke_test_cugraph_kg.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024, NVIDIA CORPORATION.
+# Copyright (c) 2023, NVIDIA CORPORATION.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -13,6 +13,7 @@
 
 import cudf
 import cugraph
+import cugraph-kg
 
 if __name__ == "__main__":
     edgelist = cudf.DataFrame({"source": ["a", "b", "c"], "destination": ["b", "c", "d"]})

--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -10,7 +10,7 @@ dependencies:
 - c-compiler
 - clang-tools==16.0.6
 - clangxx==16.0.6
-- cmake>=3.26.4
+- cmake>=3.26.4,!=3.30.0
 - cuda-nvtx=11.8
 - cuda-version=11.8
 - cudatoolkit

--- a/conda/environments/all_cuda-122_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-122_arch-x86_64.yaml
@@ -10,7 +10,7 @@ dependencies:
 - c-compiler
 - clang-tools==16.0.6
 - clangxx==16.0.6
-- cmake>=3.26.4
+- cmake>=3.26.4,!=3.30.0
 - cuda-cudart-dev
 - cuda-nvcc
 - cuda-nvtx

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -70,7 +70,7 @@ dependencies:
       - output_types: conda
         packages:
           - c-compiler
-          - cmake>=3.26.4
+          - &cmake_ver cmake>=3.26.4
           - cudnn=8.8
           - cxx-compiler
           - cython>=3.0.0
@@ -320,7 +320,7 @@ dependencies:
     common:
       - output_types: [pyproject]
         packages:
-          - cmake>=3.26.4
+          - *cmake_ver
           - cython>=3.0.0
           - ninja
           - scikit-build-core[pyproject]>=0.7.0

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -70,7 +70,7 @@ dependencies:
       - output_types: conda
         packages:
           - c-compiler
-          - &cmake_ver cmake>=3.26.4
+          - &cmake_ver cmake>=3.26.4,!=3.30.0
           - cudnn=8.8
           - cxx-compiler
           - cython>=3.0.0

--- a/python/cugraph-pg/pyproject.toml
+++ b/python/cugraph-pg/pyproject.toml
@@ -3,7 +3,7 @@
 [build-system]
 
 requires = [
-    "cmake>=3.26.4",
+    "cmake>=3.26.4,!=3.30.0",
     "cython>=3.0.0",
     "ninja",
     "scikit-build-core[pyproject]>=0.7.0",


### PR DESCRIPTION
## Description

Contributes to https://github.com/rapidsai/build-planning/issues/80

Adds constraints to avoid pulling in CMake 3.30.0, for the reasons described in that issue.