### PR TITLE
update update-version.sh to use packaging lib

### DIFF
--- a/ci/release/update-version.sh
+++ b/ci/release/update-version.sh
@@ -45,7 +45,7 @@ function sed_runner() {
 echo "${NEXT_FULL_TAG}" > VERSION
 
 # Need to distutils-normalize the original version
-NEXT_SHORT_TAG_PEP440=$(python -c "from setuptools.extern import packaging; print(packaging.version.Version('${NEXT_SHORT_TAG}'))")
+NEXT_SHORT_TAG_PEP440=$(python -c "from packaging.version import Version; print(Version('${NEXT_SHORT_TAG}'))")
 
 DEPENDENCIES=(
   cudf


### PR DESCRIPTION
This PR updates the update-version.sh script to use the packaging library, given that setuptools is no longer included by default in Python 3.12.